### PR TITLE
Slider interval bug and flickr notes

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -49,7 +49,6 @@
     +function setUpCarousels() {
       $('.carousel').carousel({
         pause: null,
-        interval: 5000,
         keyboard: false
       });
     }();

--- a/src/parsers/rss/flickr-rss-parser.php
+++ b/src/parsers/rss/flickr-rss-parser.php
@@ -70,6 +70,11 @@ class Flickr_Rss_Parser {
     return $feed_items;
   }
 
+  /** get_image( SimplePie $item ): URL as a String
+   * Look through the description field in an item for an img tag,
+   * returns the first value from the src attribute it finds. 
+   * Also will return the large image size when small is given.
+   */
   private function get_image( $item ) {
     $image_regex = '/<img[^>]+>/i';
     $image_source_regex = '/src="([^"]+)"/i';
@@ -83,6 +88,8 @@ class Flickr_Rss_Parser {
         $image_source = $source_matches[1];
       }
 
+      // see also: https://www.flickr.com/services/api/misc.urls.html
+      // if small photos are given, replace with large
       return str_replace( '_m.jpg', '_b.jpg', $image_source );
     }
 


### PR DESCRIPTION
In some cases the Javascript that sets up the slider will override the data attributes. So we'll remove the interval config from the Javascript call and let the default fall back on the slider framework. 

Also added some notes about flickr rss feed parsing 